### PR TITLE
fix: bump 2 tests‘ supported java version to 8

### DIFF
--- a/libraries/examples/kotlin-java-example/pom.xml
+++ b/libraries/examples/kotlin-java-example/pom.xml
@@ -30,6 +30,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/libraries/tools/kotlin-maven-plugin-test/pom.xml
+++ b/libraries/tools/kotlin-maven-plugin-test/pom.xml
@@ -49,6 +49,10 @@
                         <goals><goal>testCompile</goal></goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
java home配置21，使用 `scripts/kuikly-base/publish-local.sh` 脚本进行构建报错

```
[INFO] --- maven-compiler-plugin:2.3.2:testCompile (default-testCompile) @ kotlin-maven-plugin-test ---
[INFO] Compiling 6 source files to /Users/user/git/kmp/20/libraries/tools/kotlin-maven-plugin-test/target/test-classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] error: Source option 6 is no longer supported. Use 8 or later.
[ERROR] error: Target option 6 is no longer supported. Use 8 or later.
[INFO] 2 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Kotlin 2.0.255-SNAPSHOT:
[INFO] 
[INFO] Kotlin ............................................. SUCCESS [ 12.379 s]
[INFO] kotlin-maven-plugin ................................ SUCCESS [  4.807 s]
[INFO] kotlin-osgi-bundle ................................. SUCCESS [ 10.817 s]
[INFO] kotlin-archetypes .................................. SUCCESS [  2.658 s]
[INFO] kotlin-archetype-jvm ............................... SUCCESS [  2.082 s]
[INFO] kotlin-maven-allopen ............................... SUCCESS [  1.435 s]
[INFO] kotlin-maven-noarg ................................. SUCCESS [  0.328 s]
[INFO] kotlin-maven-sam-with-receiver ..................... SUCCESS [  0.256 s]
[INFO] kotlin-maven-serialization ......................... SUCCESS [  0.281 s]
[INFO] kotlin-maven-lombok ................................ SUCCESS [  0.231 s]
[INFO] Kotlin Libraries bill-of-materials ................. SUCCESS [  0.002 s]
[INFO] Kotlin Dist For Jps Meta ........................... SUCCESS [  0.072 s]
[INFO] kotlin-maven-plugin-test ........................... FAILURE [  0.015 s]
[INFO] kotlin-java-example ................................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  35.651 s
[INFO] Finished at: 2025-09-23T18:11:32+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:testCompile (default-testCompile) on project kotlin-maven-plugin-test: Compilation failure: Compilation failure: 
[ERROR] error: Source option 6 is no longer supported. Use 8 or later.
[ERROR] error: Target option 6 is no longer supported. Use 8 or later.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :kotlin-maven-plugin-test
```

最后两个项目修改source & target支持到java 8后构建通过。java6 2013年eos，感觉保留支持意义不大