### PR TITLE
修复2.0分支不能打包standalone kexe的问题

### DIFF
--- a/kotlin-native/konan/konan.properties
+++ b/kotlin-native/konan/konan.properties
@@ -771,7 +771,7 @@ targetSysRoot.linux_x64-ohos_arm64 = ohos-aarch64-sysroot-15
 
 # We could reuse host toolchain here.
 linkerKonanFlags.ohos_arm64 = -Bstatic -Bdynamic -ldl -lm -lpthread -lc++ -lc++abi \
-  --defsym __cxa_demangle=Konan_cxa_demangle -lc -lqos -lhitrace_ndk.z
+  --defsym __cxa_demangle=Konan_cxa_demangle -lc -lunwind -lqos -lhitrace_ndk.z -lhilog_ndk.z
 # targetSysroot-relative.
 #libGcc.ohos_arm64 = ../../lib/gcc/aarch64-unknown-linux-gnu/8.3.0
 targetCpu.ohos_arm64 = cortex-a57


### PR DESCRIPTION
当前2.0分支上打包可以单独执行的kexe报缺少符号。kotlin仓库中功能和性能测试依赖执行kexe，希望把这个功能调通

```kotlin
fun main() {
  println("hello")
}
```

```shell
/Users/user/git/kmp/20/kotlin-native/dist/bin/kotlinc-native -target ohos_arm64 main.kt
konanc -target ohos_arm64 main.kt
'+fp' is not a recognized feature for this target (ignoring feature)
'+asimd' is not a recognized feature for this target (ignoring feature)
'+fp' is not a recognized feature for this target (ignoring feature)
'+asimd' is not a recognized feature for this target (ignoring feature)
'+fp' is not a recognized feature for this target (ignoring feature)
'+asimd' is not a recognized feature for this target (ignoring feature)
'+fp' is not a recognized feature for this target (ignoring feature)
'+asimd' is not a recognized feature for this target (ignoring feature)
'+fp' is not a recognized feature for this target (ignoring feature)
'+asimd' is not a recognized feature for this target (ignoring feature)
'+fp' is not a recognized feature for this target (ignoring feature)
'+asimd' is not a recognized feature for this target (ignoring feature)
'+fp' is not a recognized feature for this target (ignoring feature)
'+asimd' is not a recognized feature for this target (ignoring feature)
/Users/user/.konan/dependencies/llvm-1201-macos-aarch64/bin/clang++ -cc1 -emit-obj -x ir -fno-emulated-tls -triple aarch64-linux-ohos -O1 /var/folders/5b/1lh1ghnd0lv25cddds31rzzc0000gn/T/konan_temp11277871160018298122/out.bc -o /var/folders/5b/1lh1ghnd0lv25cddds31rzzc0000gn/T/konan_temp11277871160018298122/program.kexe.o
/Users/user/.konan/dependencies/llvm-1201-macos-aarch64/bin/ld.lld --sysroot=/Users/user/Desktop/software/command-line-tools-5.0.11.110/sdk/default/openharmony/native/sysroot -export-dynamic -z relro --build-id --eh-frame-hdr -dynamic-linker /lib/ld-musl-aarch64.so.1 -o /Users/user/Desktop/program.kexe /Users/user/Desktop/software/command-line-tools-5.0.11.110/sdk/default/openharmony/native/sysroot/usr/lib/aarch64-linux-ohos/Scrt1.o /Users/user/Desktop/software/command-line-tools-5.0.11.110/sdk/default/openharmony/native/sysroot/usr/lib/aarch64-linux-ohos/crti.o /Users/user/Desktop/software/command-line-tools-5.0.11.110/sdk/default/openharmony/native/sysroot/usr/lib/aarch64-linux-ohos/crtn.o --hash-style=gnu -L/Users/user/.konan/dependencies/llvm-1201-macos-aarch64/lib/aarch64-linux-ohos -L/Users/user/.konan/dependencies/llvm-1201-macos-aarch64/lib/aarch64-linux-ohos/c++ -L/Users/user/Desktop/software/command-line-tools-5.0.11.110/sdk/default/openharmony/native/sysroot/usr/lib/aarch64-linux-ohos -S /private/var/folders/5b/1lh1ghnd0lv25cddds31rzzc0000gn/T/konan_temp11277871160018298122/program.kexe.o -Bstatic -Bdynamic -ldl -lm -lpthread -lc++ -lc++abi --defsym __cxa_demangle=Konan_cxa_demangle -lc -lqos -lhitrace_ndk.z
error: /Users/user/.konan/dependencies/llvm-1201-macos-aarch64/bin/ld.lld invocation reported errors

The (/Users/user/.konan/dependencies/llvm-1201-macos-aarch64/bin/ld.lld --sysroot=/Users/user/Desktop/software/command-line-tools-5.0.11.110/sdk/default/openharmony/native/sysroot -export-dynamic -z relro --build-id --eh-frame-hdr -dynamic-linker /lib/ld-musl-aarch64.so.1 -o /Users/user/Desktop/program.kexe /Users/user/Desktop/software/command-line-tools-5.0.11.110/sdk/default/openharmony/native/sysroot/usr/lib/aarch64-linux-ohos/Scrt1.o /Users/user/Desktop/software/command-line-tools-5.0.11.110/sdk/default/openharmony/native/sysroot/usr/lib/aarch64-linux-ohos/crti.o /Users/user/Desktop/software/command-line-tools-5.0.11.110/sdk/default/openharmony/native/sysroot/usr/lib/aarch64-linux-ohos/crtn.o --hash-style=gnu -L/Users/user/.konan/dependencies/llvm-1201-macos-aarch64/lib/aarch64-linux-ohos -L/Users/user/.konan/dependencies/llvm-1201-macos-aarch64/lib/aarch64-linux-ohos/c++ -L/Users/user/Desktop/software/command-line-tools-5.0.11.110/sdk/default/openharmony/native/sysroot/usr/lib/aarch64-linux-ohos -S /private/var/folders/5b/1lh1ghnd0lv25cddds31rzzc0000gn/T/konan_temp11277871160018298122/program.kexe.o -Bstatic -Bdynamic -ldl -lm -lpthread -lc++ -lc++abi --defsym __cxa_demangle=Konan_cxa_demangle -lc -lqos -lhitrace_ndk.z) command returned non-zero exit code: 1.
output:
ld.lld: error: undefined symbol: OH_LOG_Print
>>> referenced by out
>>>               /private/var/folders/5b/1lh1ghnd0lv25cddds31rzzc0000gn/T/konan_temp11277871160018298122/program.kexe.o:(konan::consolePrintf(char const*, ...))
>>> referenced by out
>>>               /private/var/folders/5b/1lh1ghnd0lv25cddds31rzzc0000gn/T/konan_temp11277871160018298122/program.kexe.o:(konan::consoleErrorf(char const*, ...))
>>> referenced by out
>>>               /private/var/folders/5b/1lh1ghnd0lv25cddds31rzzc0000gn/T/konan_temp11277871160018298122/program.kexe.o:(konan::consoleErrorUtf8(char const*, unsigned int))
>>> referenced 1 more times

ld.lld: error: undefined symbol: _Unwind_Backtrace
>>> referenced by out
>>>               /private/var/folders/5b/1lh1ghnd0lv25cddds31rzzc0000gn/T/konan_temp11277871160018298122/program.kexe.o:(kotlin::internal::GetCurrentStackTrace(unsigned long))
>>> referenced by out
>>>               /private/var/folders/5b/1lh1ghnd0lv25cddds31rzzc0000gn/T/konan_temp11277871160018298122/program.kexe.o:(kotlin::internal::GetCurrentStackTrace(unsigned long))
```